### PR TITLE
Expose zig-tls12 as a module

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,19 +15,9 @@ pub fn build(b: *std.Build) void {
     // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addStaticLibrary(.{
-        .name = "zig-tls12",
-        // In this case the main source file is merely a path, however, in more
-        // complicated build scripts, this could be a generated file.
+    _ = b.addModule("zig-tls12", .{
         .root_source_file = .{ .path = "src/HttpClient.zig" },
-        .target = target,
-        .optimize = optimize,
     });
-
-    // This declares intent for the library to be installed into the standard
-    // location when the user invokes the "install" step (the default step when
-    // running `zig build`).
-    b.installArtifact(lib);
 
     // Creates a step for unit testing. This only builds the test executable
     // but does not run it.


### PR DESCRIPTION
Static lib does not make much sense as no C API is being exposed, we would have to import the .zig file defeating the whole purpose.

Closes #3 